### PR TITLE
feat: restructure package with separate entry points for different use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,6 @@ const styleSwitcher = new StyleSwitcherControl({
 
 See the default class names in the `StyleSwitcherControl` source for all available keys.
 
-
 ## Contributing
 
 We welcome contributions! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,36 @@ To use a specific version instead of `@latest`:
 
 ## Usage
 
+The package provides three clear entry points for different use cases:
+
+| Entry Point | Use Case | Dependencies | Exports |
+|------------|----------|--------------|---------|
+| `map-gl-style-switcher` | Vanilla JS/TS (default) | maplibre-gl OR mapbox-gl | `StyleSwitcherControl` |
+| `map-gl-style-switcher/react` | React with custom map | react + (maplibre-gl OR mapbox-gl) | `useStyleSwitcher`, `StyleSwitcherControl` |
+| `map-gl-style-switcher/react-map-gl` | React with react-map-gl | react + react-map-gl | `MapGLStyleSwitcher`, `StyleSwitcherControl` |
+
+### Entry Point Guide
+
+#### For Vanilla JavaScript/TypeScript Users
+```ts
+import { StyleSwitcherControl } from 'map-gl-style-switcher';
+// No React dependencies required
+```
+
+#### For React with Custom Map Instance
+```tsx
+import { useStyleSwitcher } from 'map-gl-style-switcher/react';
+// Pure React hook - works with any map instance (MapLibre, Mapbox, etc.)
+// Only requires: react (no react-map-gl dependency)
+```
+
+#### For React with react-map-gl
+```tsx
+import { MapGLStyleSwitcher } from 'map-gl-style-switcher/react-map-gl';
+// React component using react-map-gl's useControl
+// Requires: react + react-map-gl
+```
+
 ### Basic MapLibre GL Integration
 
 ```ts
@@ -253,14 +283,77 @@ const styleSwitcher = new StyleSwitcherControl({
 map.addControl(styleSwitcher, 'bottom-left');
 ```
 
+### React Hook for Custom Map Instances
+
+For React applications where you manage the map instance yourself (e.g., with `useEffect`), use the `useStyleSwitcher` hook:
+
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { useStyleSwitcher } from 'map-gl-style-switcher/react';
+import maplibregl from 'maplibre-gl';
+import 'map-gl-style-switcher/dist/map-gl-style-switcher.css';
+
+const styles = [
+  {
+    id: 'voyager',
+    name: 'Voyager',
+    styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+  },
+  {
+    id: 'positron',
+    name: 'Positron',
+    styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+  },
+];
+
+function MyMapComponent() {
+  const mapContainer = useRef<HTMLDivElement>(null);
+  const map = useRef<maplibregl.Map | null>(null);
+  
+  useEffect(() => {
+    if (!mapContainer.current) return;
+    
+    map.current = new maplibregl.Map({
+      container: mapContainer.current,
+      style: styles[0].styleUrl,
+      center: [0, 0],
+      zoom: 2
+    });
+    
+    return () => map.current?.remove();
+  }, []);
+  
+  // Add style switcher control to the map
+  useStyleSwitcher(map.current, {
+    styles,
+    theme: 'auto',
+    position: 'top-right',
+    onAfterStyleChange: (from, to) => {
+      if (map.current) {
+        map.current.setStyle(to.styleUrl);
+      }
+    }
+  });
+  
+  return <div ref={mapContainer} style={{ width: '100%', height: '400px' }} />;
+}
+```
+
+**Installation for React Hook:**
+```sh
+npm install react maplibre-gl map-gl-style-switcher
+# or for Mapbox GL:
+npm install react mapbox-gl map-gl-style-switcher
+```
+
 ### React Integration with react-map-gl
 
-For React applications using `react-map-gl`, This package provides a ready-to-use `MapGLStyleSwitcher` component:
+For React applications using `react-map-gl`, this package provides a ready-to-use `MapGLStyleSwitcher` component:
 
 ```tsx
 import React, { useState } from 'react';
 import { Map } from 'react-map-gl/maplibre';
-import { MapGLStyleSwitcher } from 'map-gl-style-switcher';
+import { MapGLStyleSwitcher } from 'map-gl-style-switcher/react-map-gl';
 import 'map-gl-style-switcher/dist/map-gl-style-switcher.css';
 
 const styles = [
@@ -409,6 +502,105 @@ const MapComponent = () => {
   );
 };
 ```
+
+### React Integration with Custom Map Instance
+
+For React applications using any map library (MapLibre, Mapbox, etc.) with `useEffect`, you can use the `useStyleSwitcher` hook:
+
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { useStyleSwitcher } from 'map-gl-style-switcher/react';
+import maplibregl from 'maplibre-gl';
+import 'map-gl-style-switcher/dist/map-gl-style-switcher.css';
+
+const styles = [
+  {
+    id: 'voyager',
+    name: 'Voyager',
+    image: './voyager.png',
+    styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+    description: 'Voyager style from Carto',
+  },
+  {
+    id: 'positron',
+    name: 'Positron',
+    image: './positron.png',
+    styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+    description: 'Positron style from Carto',
+  },
+];
+
+function MyMapComponent() {
+  const mapContainer = useRef<HTMLDivElement>(null);
+  const map = useRef<maplibregl.Map | null>(null);
+  
+  useEffect(() => {
+    if (!mapContainer.current) return;
+    
+    map.current = new maplibregl.Map({
+      container: mapContainer.current,
+      style: styles[0].styleUrl,
+      center: [0, 0],
+      zoom: 2
+    });
+    
+    return () => map.current?.remove();
+  }, []);
+  
+  // Add style switcher control to the map
+  useStyleSwitcher(map.current, {
+    styles,
+    theme: 'auto',
+    position: 'top-right',
+    showLabels: true,
+    showImages: true,
+    activeStyleId: styles[0].id,
+    onAfterStyleChange: (from, to) => {
+      if (map.current) {
+        map.current.setStyle(to.styleUrl);
+      }
+    },
+  });
+  
+  return (
+    <div
+      ref={mapContainer}
+      style={{ width: '100%', height: '400px' }}
+    />
+  );
+}
+```
+
+**Installation for React Hook:**
+
+```sh
+npm install maplibre-gl map-gl-style-switcher
+# or for Mapbox GL
+npm install mapbox-gl map-gl-style-switcher
+```
+
+#### useStyleSwitcher Hook
+
+The `useStyleSwitcher` hook accepts a map instance and options:
+
+```tsx
+const control = useStyleSwitcher(map, {
+  styles: StyleItem[]; // Required: Array of map styles
+  activeStyleId?: string; // Currently active style ID
+  theme?: 'light' | 'dark' | 'auto'; // UI theme
+  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  showLabels?: boolean; // Show style names
+  showImages?: boolean; // Show style thumbnails
+  animationDuration?: number; // Animation duration in ms
+  maxHeight?: number; // Maximum height of the control
+  rtl?: boolean; // Right-to-left layout
+  classNames?: Partial<StyleSwitcherClassNames>; // Custom CSS classes
+  onBeforeStyleChange?: (from: StyleItem, to: StyleItem) => void;
+  onAfterStyleChange?: (from: StyleItem, to: StyleItem) => void;
+});
+```
+
+**Note:** This hook automatically handles adding/removing the control when the map or options change.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A TypeScript control for switching Mapbox GL / MapLibre GL map styles. Easily ad
 
 - `StyleSwitcherControl` - Direct IControl implementation for Mapbox/MapLibre GL
 - `MapGLStyleSwitcher` - React component for react-map-gl integration
-_Live demo of the style switcher control in action_
+  _Live demo of the style switcher control in action_
 
 **<a href="https://map-gl-style-switcher.netlify.app/" target="_blank">🌐 Live Demo</a>**
 
@@ -24,6 +24,7 @@ _Live demo of the style switcher control in action_
 ## Available Styles
 
 ![Available Styles](./images/styles.png)
+
 ## Features
 
 - IControl implementation for Mapbox GL / MapLibre GL
@@ -57,97 +58,84 @@ pnpm add map-gl-style-switcher
 
 For quick prototyping or when you don't want to use a build system, you can include the package directly from a CDN:
 
-### unpkg CDN
+### unpkg CDN and jsDelivr CDN
 
 ```html
 <!DOCTYPE html>
 <html>
-<head>
-  <!-- MapLibre GL CSS -->
-  <link href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" rel="stylesheet" />
-  
-  <!-- Style Switcher CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/map-gl-style-switcher@latest/dist/map-gl-style-switcher.css">
-</head>
-<body>
-  <div id="map" style="width: 100%; height: 100vh;"></div>
+  <head>
+    <!-- jsDelivr CDN -->
+    <!-- MapLibre GL CSS -->
+    <!-- <link href="https://cdn.jsdelivr.net/npm/maplibre-gl@4/dist/maplibre-gl.css" rel="stylesheet" /> -->
 
-  <!-- MapLibre GL JS -->
-  <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
-  
-  <!-- Style Switcher UMD -->
-  <script src="https://unpkg.com/map-gl-style-switcher@latest/dist/index.umd.js"></script>
-  
-  <script>
-    // StyleSwitcherControl is available globally as MapGLStyleSwitcher.StyleSwitcherControl
-    const { StyleSwitcherControl } = MapGLStyleSwitcher;
-    
-    const styles = [
-      {
-        id: 'voyager',
-        name: 'Voyager',
-        image: 'https://unpkg.com/map-gl-style-switcher@latest/public/voyager.png',
-        styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
-        description: 'Voyager style from Carto',
-      },
-      {
-        id: 'positron',
-        name: 'Positron',
-        image: 'https://unpkg.com/map-gl-style-switcher@latest/public/positron.png',
-        styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-        description: 'Positron style from Carto',
-      }
-    ];
-    
-    const map = new maplibregl.Map({
-      container: 'map',
-      style: styles[0].styleUrl,
-      center: [0, 0],
-      zoom: 2
-    });
-    
-    const styleSwitcher = new StyleSwitcherControl({
-      styles: styles,
-      theme: 'auto',
-      activeStyleId: styles[0].id,
-      onAfterStyleChange: (from, to) => {
-        map.setStyle(to.styleUrl);
-      }
-    });
-    
-    map.addControl(styleSwitcher, 'bottom-left');
-  </script>
-</body>
-</html>
-```
+    <!-- Style Switcher CSS -->
+    <!-- <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/map-gl-style-switcher@latest/dist/map-gl-style-switcher.css"
+    /> -->
+    <!-- MapLibre GL CSS -->
+    <link href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" rel="stylesheet" />
 
-### jsDelivr CDN
+    <!-- Style Switcher CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/map-gl-style-switcher@latest/dist/map-gl-style-switcher.css"
+    />
+  </head>
+  <body>
+    <div id="map" style="width: 100%; height: 100vh;"></div>
+    <!-- jsDelivr CDN -->
+    <!-- MapLibre GL JS -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/maplibre-gl@4/dist/maplibre-gl.js"></script> -->
 
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <!-- MapLibre GL CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/maplibre-gl@4/dist/maplibre-gl.css" rel="stylesheet" />
-  
-  <!-- Style Switcher CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/map-gl-style-switcher@latest/dist/map-gl-style-switcher.css">
-</head>
-<body>
-  <div id="map" style="width: 100%; height: 100vh;"></div>
+    <!-- Style Switcher UMD -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/map-gl-style-switcher@latest/dist/index.umd.js"></script> -->
+    <!-- MapLibre GL JS -->
+    <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
 
-  <!-- MapLibre GL JS -->
-  <script src="https://cdn.jsdelivr.net/npm/maplibre-gl@4/dist/maplibre-gl.js"></script>
-  
-  <!-- Style Switcher UMD -->
-  <script src="https://cdn.jsdelivr.net/npm/map-gl-style-switcher@latest/dist/index.umd.js"></script>
-  
-  <script>
-    // Same JavaScript code as above
-    const { StyleSwitcherControl } = MapGLStyleSwitcher;
-    // ... rest of the code
-  </script>
-</body>
+    <!-- Style Switcher UMD -->
+    <script src="https://unpkg.com/map-gl-style-switcher@latest/dist/index.umd.js"></script>
+
+    <script>
+      // StyleSwitcherControl is available globally as MapGLStyleSwitcher.StyleSwitcherControl
+      const { StyleSwitcherControl } = MapGLStyleSwitcher;
+
+      const styles = [
+        {
+          id: 'voyager',
+          name: 'Voyager',
+          image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
+          styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+          description: 'Voyager style from Carto',
+        },
+        {
+          id: 'positron',
+          name: 'Positron',
+          image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
+          styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+          description: 'Positron style from Carto',
+        },
+      ];
+
+      const map = new maplibregl.Map({
+        container: 'map',
+        style: styles[0].styleUrl,
+        center: [0, 0],
+        zoom: 2,
+      });
+
+      const styleSwitcher = new StyleSwitcherControl({
+        styles: styles,
+        theme: 'auto',
+        activeStyleId: styles[0].id,
+        onAfterStyleChange: (from, to) => {
+          map.setStyle(to.styleUrl);
+        },
+      });
+
+      map.addControl(styleSwitcher, 'bottom-left');
+    </script>
+  </body>
 </html>
 ```
 
@@ -158,44 +146,26 @@ For modern browsers that support ES modules:
 ```html
 <script type="module">
   import { StyleSwitcherControl } from 'https://unpkg.com/map-gl-style-switcher@latest/dist/index.js';
-  
+
   // Your code here
   const styleSwitcher = new StyleSwitcherControl({
     styles: styles,
-    theme: 'auto'
+    theme: 'auto',
   });
 </script>
 ```
 
-### Specific Version
-
-To use a specific version instead of `@latest`:
-
-```html
-<!-- Replace @latest with specific version, e.g., @0.7.2 -->
-<link rel="stylesheet" href="https://unpkg.com/map-gl-style-switcher@0.7.2/dist/map-gl-style-switcher.css">
-<script src="https://unpkg.com/map-gl-style-switcher@0.7.2/dist/index.umd.js"></script>
-```
-
-## Usage
-
-The package provides three clear entry points for different use cases:
-
-| Entry Point | Use Case | Dependencies | Exports |
-|------------|----------|--------------|---------|
-| `map-gl-style-switcher` | Vanilla JS/TS (default) | maplibre-gl OR mapbox-gl | `StyleSwitcherControl` |
-| `map-gl-style-switcher/react` | React with custom map | react + (maplibre-gl OR mapbox-gl) | `useStyleSwitcher`, `StyleSwitcherControl` |
-| `map-gl-style-switcher/react-map-gl` | React with react-map-gl | react + react-map-gl | `MapGLStyleSwitcher`, `StyleSwitcherControl` |
-
 ### Entry Point Guide
 
 #### For Vanilla JavaScript/TypeScript Users
+
 ```ts
 import { StyleSwitcherControl } from 'map-gl-style-switcher';
 // No React dependencies required
 ```
 
 #### For React with Custom Map Instance
+
 ```tsx
 import { useStyleSwitcher } from 'map-gl-style-switcher/react';
 // Pure React hook - works with any map instance (MapLibre, Mapbox, etc.)
@@ -203,6 +173,7 @@ import { useStyleSwitcher } from 'map-gl-style-switcher/react';
 ```
 
 #### For React with react-map-gl
+
 ```tsx
 import { MapGLStyleSwitcher } from 'map-gl-style-switcher/react-map-gl';
 // React component using react-map-gl's useControl
@@ -221,28 +192,28 @@ const styles = [
   {
     id: 'voyager',
     name: 'Voyager',
-    image: './voyager.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
     description: 'Voyager style from Carto',
   },
   {
     id: 'positron',
     name: 'Positron',
-    image: './positron.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
     description: 'Positron style from Carto',
   },
   {
     id: 'dark-matter',
     name: 'Dark Matter',
-    image: './dark.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/dark.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
     description: 'Dark style from Carto',
   },
   {
     id: 'arcgis-hybrid',
     name: 'ArcGIS Hybrid',
-    image: './arcgis-hybrid.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/arcgis-hybrid.png',
     styleUrl:
       'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/arcgis_hybrid.json',
     description: 'Hybrid Satellite style from ESRI',
@@ -250,7 +221,7 @@ const styles = [
   {
     id: 'osm',
     name: 'OSM',
-    image: './osm.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/osm.png',
     styleUrl:
       'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/openStreetMap.json',
     description: 'OSM style',
@@ -297,32 +268,36 @@ const styles = [
   {
     id: 'voyager',
     name: 'Voyager',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+    description: 'Voyager style from Carto',
   },
   {
     id: 'positron',
     name: 'Positron',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+    description: 'Positron style from Carto',
   },
 ];
 
 function MyMapComponent() {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
-  
+
   useEffect(() => {
     if (!mapContainer.current) return;
-    
+
     map.current = new maplibregl.Map({
       container: mapContainer.current,
       style: styles[0].styleUrl,
       center: [0, 0],
-      zoom: 2
+      zoom: 2,
     });
-    
+
     return () => map.current?.remove();
   }, []);
-  
+
   // Add style switcher control to the map
   useStyleSwitcher(map.current, {
     styles,
@@ -332,18 +307,11 @@ function MyMapComponent() {
       if (map.current) {
         map.current.setStyle(to.styleUrl);
       }
-    }
+    },
   });
-  
+
   return <div ref={mapContainer} style={{ width: '100%', height: '400px' }} />;
 }
-```
-
-**Installation for React Hook:**
-```sh
-npm install react maplibre-gl map-gl-style-switcher
-# or for Mapbox GL:
-npm install react mapbox-gl map-gl-style-switcher
 ```
 
 ### React Integration with react-map-gl
@@ -360,28 +328,28 @@ const styles = [
   {
     id: 'voyager',
     name: 'Voyager',
-    image: './voyager.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
     description: 'Voyager style from Carto',
   },
   {
     id: 'positron',
     name: 'Positron',
-    image: './positron.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
     description: 'Positron style from Carto',
   },
   {
     id: 'dark-matter',
     name: 'Dark Matter',
-    image: './dark.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/dark.png',
     styleUrl: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
     description: 'Dark style from Carto',
   },
   {
     id: 'arcgis-hybrid',
     name: 'ArcGIS Hybrid',
-    image: './arcgis-hybrid.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/arcgis-hybrid.png',
     styleUrl:
       'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/arcgis_hybrid.json',
     description: 'Hybrid Satellite style from ESRI',
@@ -389,7 +357,7 @@ const styles = [
   {
     id: 'osm',
     name: 'OSM',
-    image: './osm.png',
+    image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/osm.png',
     styleUrl:
       'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/openStreetMap.json',
     description: 'OSM style',
@@ -422,12 +390,6 @@ export const MapComponent = () => {
     </Map>
   );
 };
-```
-
-**Installation for React:**
-
-```sh
-npm install react-map-gl maplibre-gl map-gl-style-switcher
 ```
 
 #### MapGLStyleSwitcher Props
@@ -503,103 +465,6 @@ const MapComponent = () => {
 };
 ```
 
-### React Integration with Custom Map Instance
-
-For React applications using any map library (MapLibre, Mapbox, etc.) with `useEffect`, you can use the `useStyleSwitcher` hook:
-
-```tsx
-import React, { useEffect, useRef } from 'react';
-import { useStyleSwitcher } from 'map-gl-style-switcher/react';
-import maplibregl from 'maplibre-gl';
-import 'map-gl-style-switcher/dist/map-gl-style-switcher.css';
-
-const styles = [
-  {
-    id: 'voyager',
-    name: 'Voyager',
-    image: './voyager.png',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
-    description: 'Voyager style from Carto',
-  },
-  {
-    id: 'positron',
-    name: 'Positron',
-    image: './positron.png',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-    description: 'Positron style from Carto',
-  },
-];
-
-function MyMapComponent() {
-  const mapContainer = useRef<HTMLDivElement>(null);
-  const map = useRef<maplibregl.Map | null>(null);
-  
-  useEffect(() => {
-    if (!mapContainer.current) return;
-    
-    map.current = new maplibregl.Map({
-      container: mapContainer.current,
-      style: styles[0].styleUrl,
-      center: [0, 0],
-      zoom: 2
-    });
-    
-    return () => map.current?.remove();
-  }, []);
-  
-  // Add style switcher control to the map
-  useStyleSwitcher(map.current, {
-    styles,
-    theme: 'auto',
-    position: 'top-right',
-    showLabels: true,
-    showImages: true,
-    activeStyleId: styles[0].id,
-    onAfterStyleChange: (from, to) => {
-      if (map.current) {
-        map.current.setStyle(to.styleUrl);
-      }
-    },
-  });
-  
-  return (
-    <div
-      ref={mapContainer}
-      style={{ width: '100%', height: '400px' }}
-    />
-  );
-}
-```
-
-**Installation for React Hook:**
-
-```sh
-npm install maplibre-gl map-gl-style-switcher
-# or for Mapbox GL
-npm install mapbox-gl map-gl-style-switcher
-```
-
-#### useStyleSwitcher Hook
-
-The `useStyleSwitcher` hook accepts a map instance and options:
-
-```tsx
-const control = useStyleSwitcher(map, {
-  styles: StyleItem[]; // Required: Array of map styles
-  activeStyleId?: string; // Currently active style ID
-  theme?: 'light' | 'dark' | 'auto'; // UI theme
-  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-  showLabels?: boolean; // Show style names
-  showImages?: boolean; // Show style thumbnails
-  animationDuration?: number; // Animation duration in ms
-  maxHeight?: number; // Maximum height of the control
-  rtl?: boolean; // Right-to-left layout
-  classNames?: Partial<StyleSwitcherClassNames>; // Custom CSS classes
-  onBeforeStyleChange?: (from: StyleItem, to: StyleItem) => void;
-  onAfterStyleChange?: (from: StyleItem, to: StyleItem) => void;
-});
-```
-
 **Note:** This hook automatically handles adding/removing the control when the map or options change.
 
 ## Examples
@@ -620,90 +485,8 @@ This example demonstrates:
 - MapLibre GL integration with react-map-gl
 - MapGLStyleSwitcher component usage
 - Multiple basemap styles with thumbnails
-- Responsive design with auto theme detection
-- Style switching with smooth transitions
 
 [View the complete example →](examples/react-map-gl/)
-
-### Vanilla JavaScript Example
-
-The main demo at the root level demonstrates vanilla JavaScript usage:
-
-```bash
-npm install
-npm run dev
-```
-
-This example shows:
-
-- Pure TypeScript/JavaScript implementation
-- MapLibre GL integration
-- StyleSwitcherControl direct usage
-- Multiple themes and configuration options
-
-
-The style switcher supports various map styles. Here are some popular options you can use:
-
-### Carto Basemaps
-
-- **Voyager** - A balanced, colorful style perfect for data visualization and general mapping applications
-- **Positron** - A clean, minimal light basemap ideal for overlaying data with maximum contrast
-- **Dark Matter** - A dark theme basemap excellent for creating striking data visualizations and night mode interfaces
-
-### Satellite & Hybrid
-
-- **ArcGIS Hybrid** - Combines satellite imagery with street labels, perfect for geographic context and navigation
-- **Satellite** - High-resolution satellite imagery for detailed geographic analysis
-
-### OpenStreetMap
-
-- **OSM (OpenStreetMap)** - Community-driven open-source mapping with detailed street-level information
-
-### Example Styles Configuration
-
-```ts
-const styles = [
-  {
-    id: 'voyager',
-    name: 'Voyager',
-    image: './voyager.png',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
-    description: 'Voyager style from Carto',
-  },
-  {
-    id: 'positron',
-    name: 'Positron',
-    image: './positron.png',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-    description: 'Positron style from Carto',
-  },
-  {
-    id: 'dark-matter',
-    name: 'Dark Matter',
-    image: './dark.png',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
-    description: 'Dark style from Carto',
-  },
-  {
-    id: 'arcgis-hybrid',
-    name: 'ArcGIS Hybrid',
-    image: './arcgis-hybrid.png',
-    styleUrl:
-      'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/arcgis_hybrid.json',
-    description: 'Hybrid Satellite style from ESRI',
-  },
-  {
-    id: 'osm',
-    name: 'OSM',
-    image: './osm.png',
-    styleUrl:
-      'https://raw.githubusercontent.com/go2garret/maps/main/src/assets/json/openStreetMap.json',
-    description: 'OSM style',
-  },
-];
-```
-
-> **Note**: The `description` property is optional and will be shown as a tooltip when users hover over a style option.
 
 ## Configuration Options
 
@@ -778,99 +561,6 @@ const styleSwitcher = new StyleSwitcherControl({
 
 See the default class names in the `StyleSwitcherControl` source for all available keys.
 
-## File Structure
-
-```
-map-gl-style-switcher/
-├── src/
-│   ├── components/
-│   │   ├── StyleSwitcherControl.ts    # Main IControl implementation
-│   │   └── MapGLStyleSwitcher.tsx     # React component for react-map-gl
-│   ├── styles/
-│   │   └── style-switcher.css         # Control styles (themes, RTL support)
-│   ├── types/
-│   │   ├── index.ts                   # TypeScript type definitions
-│   │   └── css.d.ts                   # CSS module declarations
-│   ├── tests/
-│   │   ├── StyleSwitcherControl.test.ts # Core control test suite
-│   │   ├── MapGLStyleSwitcher.test.tsx  # React component test suite
-│   │   └── test-setup.ts              # Jest test setup
-│   ├── demo/
-│   │   ├── main.tsx                   # Demo entry point
-│   │   ├── App.tsx                    # Demo component
-│   │   └── index.css                  # Demo-specific styles
-│   └── index.ts                       # Package entry point
-├── examples/
-│   └── react-map-gl/                  # Complete React example
-│       ├── src/
-│       │   ├── App.tsx                # Example React application
-│       │   └── main.tsx               # React entry point
-│       ├── package.json               # Example dependencies
-│       └── vite.config.ts             # Vite configuration
-├── dist/                              # Built package output
-│   ├── index.js                       # ES Module
-│   ├── index.umd.js                   # UMD Module
-│   ├── index.d.ts                     # TypeScript declarations
-│   └── map-gl-style-switcher.css       # Bundled CSS
-├── package.json                       # Package configuration
-├── rollup.config.js                   # Production build configuration
-├── vite.config.ts                     # Development build configuration
-├── jest.config.js                     # Test configuration
-├── tsconfig.json                      # TypeScript configuration
-└── README.md                          # Documentation
-```
-
-## Development
-
-This project uses npm for dependency management.
-
-### Prerequisites
-
-```sh
-# Ensure you have Node.js 16+ and npm 8+ installed
-node --version
-npm --version
-```
-
-### Quick Start
-
-```sh
-# Install dependencies
-npm install
-
-# Start development server
-npm run dev
-
-# Build for production
-npm run build
-
-# Run tests
-npm test
-
-# Lint and format code
-npm run lint
-npm run format
-
-# Validate before publishing
-npm run validate
-```
-
-## Build for npm
-
-The project uses Rollup for optimized production builds, generating:
-
-- `dist/index.js` - ES module format
-- `dist/index.umd.js` - UMD format for browser usage
-- `dist/index.d.ts` - TypeScript declarations
-- `dist/map-gl-style-switcher.css` - Minified CSS styles
-
-```sh
-# Standard build
-npm run build
-
-# Production build with full validation
-npm run build:prod
-```
 
 ## Contributing
 
@@ -909,23 +599,6 @@ We welcome contributions! Please feel free to submit a Pull Request. For major c
    ```
 
 6. **Submit a pull request**
-
-### Available Scripts
-
-- `npm run dev` - Start development server with hot reload
-- `npm run build` - Build library with Rollup (ES modules, UMD, TypeScript declarations, and CSS)
-- `npm run build:prod` - Production build with validation (type-check, lint, and build)
-- `npm run build:watch` - Build in watch mode with Rollup
-- `npm test` - Run tests
-- `npm run test:watch` - Run tests in watch mode
-- `npm run test:coverage` - Run tests with coverage
-- `npm run lint` - Lint code
-- `npm run lint:fix` - Lint and auto-fix issues
-- `npm run format` - Format code with Prettier
-- `npm run format:check` - Check code formatting
-- `npm run validate` - Run all validation checks
-- `npm run type-check` - Type check TypeScript
-- `npm run clean` - Clean build artifacts
 
 ### Guidelines
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Live demo of the style switcher control in action_
 
 **<a href="https://map-gl-style-switcher.netlify.app/" target="_blank">🌐 Live Demo</a>**
 
-## GIF Demo
+## Animated Demo
 
 ![Demo GIF](./images/demo.gif)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-gl-style-switcher",
-  "version": "0.7.5",
+  "version": "0.9.0",
   "description": "A customizable style switcher control for Mapbox GL JS and MapLibre GL JS",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,24 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.js"
+    },
+    "./react-map-gl": {
+      "types": "./dist/react-map-gl.d.ts",
+      "import": "./dist/react-map-gl.js",
+      "require": "./dist/react-map-gl.js"
+    },
+    "./dist/map-gl-style-switcher.css": "./dist/map-gl-style-switcher.css"
+  },
   "files": [
     "dist",
     "README.md",
@@ -41,21 +59,13 @@
   "demo": "https://map-gl-style-switcher.netlify.app",
   "peerDependencies": {
     "mapbox-gl": ">=1.0.0",
-    "maplibre-gl": ">=2.0.0",
-    "react": ">=16.8.0",
-    "react-map-gl": ">=7.0.0"
+    "maplibre-gl": ">=2.0.0"
   },
   "peerDependenciesMeta": {
     "mapbox-gl": {
       "optional": true
     },
     "maplibre-gl": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "react-map-gl": {
       "optional": true
     }
   },

--- a/src/components/useStyleSwitcher.ts
+++ b/src/components/useStyleSwitcher.ts
@@ -1,6 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import { StyleSwitcherControl } from './StyleSwitcherControl';
 import type { StyleSwitcherControlOptions } from './StyleSwitcherControl';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MapInstance = any; // MapLibre GL or Mapbox GL Map instance
 
 interface UseStyleSwitcherOptions extends StyleSwitcherControlOptions {
   /** Position of the control on the map */
@@ -49,11 +52,14 @@ interface UseStyleSwitcherOptions extends StyleSwitcherControlOptions {
  * ```
  */
 export function useStyleSwitcher(
-  map: maplibregl.Map | mapboxgl.Map | null,
+  map: MapInstance | null,
   options: UseStyleSwitcherOptions
 ) {
   const controlRef = useRef<StyleSwitcherControl | null>(null);
   const { position, ...controlOptions } = options;
+
+  // Stringify options for deep comparison
+  const optionsKey = useMemo(() => JSON.stringify(controlOptions), [controlOptions]);
 
   useEffect(() => {
     if (!map) return;
@@ -68,19 +74,7 @@ export function useStyleSwitcher(
         controlRef.current = null;
       }
     };
-  }, [map, controlOptions, position]);
-
-  useEffect(() => {
-    // Update control options when they change
-    if (controlRef.current && controlOptions) {
-      // Remove and re-add control with new options
-      if (map) {
-        map.removeControl(controlRef.current);
-        controlRef.current = new StyleSwitcherControl(controlOptions);
-        map.addControl(controlRef.current, position || 'top-right');
-      }
-    }
-  }, [map, controlOptions, position]);
+  }, [map, position, optionsKey, controlOptions]);
 
   return controlRef.current;
 }

--- a/src/components/useStyleSwitcher.ts
+++ b/src/components/useStyleSwitcher.ts
@@ -59,7 +59,10 @@ export function useStyleSwitcher(
   const { position, ...controlOptions } = options;
 
   // Stringify options for deep comparison
-  const optionsKey = useMemo(() => JSON.stringify(controlOptions), [controlOptions]);
+  const optionsKey = useMemo(
+    () => JSON.stringify(controlOptions),
+    [controlOptions]
+  );
 
   useEffect(() => {
     if (!map) return;

--- a/src/components/useStyleSwitcher.ts
+++ b/src/components/useStyleSwitcher.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react';
+import { StyleSwitcherControl } from './StyleSwitcherControl';
+import type { StyleSwitcherControlOptions } from './StyleSwitcherControl';
+
+interface UseStyleSwitcherOptions extends StyleSwitcherControlOptions {
+  /** Position of the control on the map */
+  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+}
+
+/**
+ * React hook for using StyleSwitcherControl with any map instance
+ *
+ * @example
+ * ```tsx
+ * import { useEffect, useRef } from 'react';
+ * import { useStyleSwitcher } from 'map-gl-style-switcher/react';
+ * import maplibregl from 'maplibre-gl';
+ *
+ * function MyMapComponent() {
+ *   const mapContainer = useRef<HTMLDivElement>(null);
+ *   const map = useRef<maplibregl.Map | null>(null);
+ *
+ *   const styles = [
+ *     { id: 'streets', name: 'Streets', styleUrl: 'mapbox://styles/mapbox/streets-v11' },
+ *     { id: 'satellite', name: 'Satellite', styleUrl: 'mapbox://styles/mapbox/satellite-v9' }
+ *   ];
+ *
+ *   useEffect(() => {
+ *     if (!mapContainer.current) return;
+ *
+ *     map.current = new maplibregl.Map({
+ *       container: mapContainer.current,
+ *       style: styles[0].styleUrl,
+ *       center: [0, 0],
+ *       zoom: 2
+ *     });
+ *
+ *     return () => map.current?.remove();
+ *   }, []);
+ *
+ *   useStyleSwitcher(map.current, {
+ *     styles,
+ *     theme: 'auto',
+ *     position: 'top-right'
+ *   });
+ *
+ *   return <div ref={mapContainer} style={{ width: '100%', height: '400px' }} />;
+ * }
+ * ```
+ */
+export function useStyleSwitcher(
+  map: maplibregl.Map | mapboxgl.Map | null,
+  options: UseStyleSwitcherOptions
+) {
+  const controlRef = useRef<StyleSwitcherControl | null>(null);
+  const { position, ...controlOptions } = options;
+
+  useEffect(() => {
+    if (!map) return;
+
+    // Create and add the control
+    controlRef.current = new StyleSwitcherControl(controlOptions);
+    map.addControl(controlRef.current, position || 'top-right');
+
+    return () => {
+      if (controlRef.current && map) {
+        map.removeControl(controlRef.current);
+        controlRef.current = null;
+      }
+    };
+  }, [map, controlOptions, position]);
+
+  useEffect(() => {
+    // Update control options when they change
+    if (controlRef.current && controlOptions) {
+      // Remove and re-add control with new options
+      if (map) {
+        map.removeControl(controlRef.current);
+        controlRef.current = new StyleSwitcherControl(controlOptions);
+        map.addControl(controlRef.current, position || 'top-right');
+      }
+    }
+  }, [map, controlOptions, position]);
+
+  return controlRef.current;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
-// Package entry point
+// Package entry point - Vanilla JavaScript/TypeScript only (for backward compatibility)
 export { StyleSwitcherControl } from './components/StyleSwitcherControl';
 export type {
   StyleItem,
   StyleSwitcherControlOptions,
   StyleSwitcherClassNames,
 } from './components/StyleSwitcherControl';
-
-// React component for react-map-gl integration (requires react-map-gl to be installed separately)
-export { MapGLStyleSwitcher } from './components/MapGLStyleSwitcher';

--- a/src/react-map-gl.ts
+++ b/src/react-map-gl.ts
@@ -1,0 +1,9 @@
+// React entry point for react-map-gl integration - includes component using useControl
+export { MapGLStyleSwitcher } from './components/MapGLStyleSwitcher.js';
+export { StyleSwitcherControl } from './components/StyleSwitcherControl.js';
+export type {
+  StyleItem,
+  StyleSwitcherControlOptions,
+  StyleSwitcherClassNames,
+  IControl,
+} from './types/index.js';

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,9 @@
+// React entry point for custom map instances - pure React hook (no react-map-gl dependency)
+export { useStyleSwitcher } from './components/useStyleSwitcher.js';
+export { StyleSwitcherControl } from './components/StyleSwitcherControl.js';
+export type {
+  StyleItem,
+  StyleSwitcherControlOptions,
+  StyleSwitcherClassNames,
+  IControl,
+} from './types/index.js';

--- a/src/tests/useStyleSwitcher.test.ts
+++ b/src/tests/useStyleSwitcher.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, cleanup } from '@testing-library/react';
+import { useStyleSwitcher } from '../components/useStyleSwitcher';
+import { StyleSwitcherControl } from '../components/StyleSwitcherControl';
+import type { StyleItem } from '../components/StyleSwitcherControl';
+
+// Mock StyleSwitcherControl
+jest.mock('../components/StyleSwitcherControl', () => ({
+  StyleSwitcherControl: jest.fn(),
+}));
+
+const MockedStyleSwitcherControl = StyleSwitcherControl as jest.MockedClass<typeof StyleSwitcherControl>;
+
+describe('useStyleSwitcher', () => {
+  const mockStyles: StyleItem[] = [
+    {
+      id: 'voyager',
+      name: 'Voyager',
+      image: 'https://example.com/voyager.png',
+      styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+      description: 'Voyager style from Carto',
+    },
+    {
+      id: 'positron',
+      name: 'Positron',
+      image: 'https://example.com/positron.png',
+      styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+      description: 'Positron style from Carto',
+    },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockMap: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockControlInstance: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMap = {
+      addControl: jest.fn(),
+      removeControl: jest.fn(),
+    };
+
+    mockControlInstance = {
+      onAdd: jest.fn(),
+      onRemove: jest.fn(),
+      getDefaultPosition: jest.fn(() => 'top-right'),
+    };
+
+    MockedStyleSwitcherControl.mockImplementation(() => mockControlInstance);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should not add control when map is null', () => {
+    const { result } = renderHook(() =>
+      useStyleSwitcher(null, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+      })
+    );
+
+    expect(MockedStyleSwitcherControl).not.toHaveBeenCalled();
+    expect(result.current).toBeNull();
+  });
+
+  test('should add control to map when map is provided', () => {
+    renderHook(() =>
+      useStyleSwitcher(mockMap, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+      })
+    );
+
+    expect(MockedStyleSwitcherControl).toHaveBeenCalledWith({
+      styles: mockStyles,
+      activeStyleId: 'voyager',
+    });
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+  });
+
+  test('should use custom position when provided', () => {
+    renderHook(() =>
+      useStyleSwitcher(mockMap, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+        position: 'bottom-left',
+      })
+    );
+
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'bottom-left');
+  });
+
+  test('should remove control when component unmounts', () => {
+    const { unmount } = renderHook(() =>
+      useStyleSwitcher(mockMap, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+      })
+    );
+
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+
+    unmount();
+
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+  });
+
+  test('should remove and re-add control when map changes', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const newMockMap: any = {
+      addControl: jest.fn(),
+      removeControl: jest.fn(),
+    };
+
+    const { rerender } = renderHook(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ({ map }: { map: any }) =>
+        useStyleSwitcher(map, {
+          styles: mockStyles,
+          activeStyleId: 'voyager',
+        }),
+      {
+        initialProps: { map: mockMap },
+      }
+    );
+
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+
+    // Change the map
+    rerender({ map: newMockMap });
+
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+    expect(newMockMap.addControl).toHaveBeenCalledWith(expect.any(Object), 'top-right');
+  });
+
+  test('should recreate control when options change', () => {
+    const initialOptions = {
+      styles: mockStyles,
+      activeStyleId: 'voyager',
+    };
+
+    const { rerender } = renderHook(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ({ options }: { options: any }) => 
+        useStyleSwitcher(mockMap, options),
+      {
+        initialProps: {
+          options: initialOptions,
+        },
+      }
+    );
+
+    expect(MockedStyleSwitcherControl).toHaveBeenCalledTimes(1);
+    expect(mockMap.addControl).toHaveBeenCalledTimes(1);
+
+    // Change options
+    const newOptions = {
+      styles: mockStyles,
+      activeStyleId: 'positron',
+      theme: 'dark' as const,
+    };
+
+    rerender({
+      options: newOptions,
+    });
+
+    // Should remove old control and add new one
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+    expect(MockedStyleSwitcherControl).toHaveBeenCalledTimes(2);
+    expect(MockedStyleSwitcherControl).toHaveBeenLastCalledWith({
+      styles: mockStyles,
+      activeStyleId: 'positron',
+      theme: 'dark',
+    });
+    expect(mockMap.addControl).toHaveBeenCalledTimes(2);
+  });
+
+  test('should recreate control when position changes', () => {
+    const { rerender } = renderHook(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ({ position }: { position: any }) =>
+        useStyleSwitcher(mockMap, {
+          styles: mockStyles,
+          activeStyleId: 'voyager',
+          position,
+        }),
+      {
+        initialProps: { position: 'top-right' },
+      }
+    );
+
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+
+    // Change position
+    rerender({ position: 'bottom-left' });
+
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+    expect(mockMap.addControl).toHaveBeenCalledWith(expect.any(Object), 'bottom-left');
+  });
+
+  test('should handle all control options', () => {
+    const onBeforeStyleChange = jest.fn();
+    const onAfterStyleChange = jest.fn();
+
+    renderHook(() =>
+      useStyleSwitcher(mockMap, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+        onBeforeStyleChange,
+        onAfterStyleChange,
+        theme: 'light',
+        position: 'top-left',
+        showLabels: true,
+        showImages: false,
+      })
+    );
+
+    expect(MockedStyleSwitcherControl).toHaveBeenCalledWith({
+      styles: mockStyles,
+      activeStyleId: 'voyager',
+      onBeforeStyleChange,
+      onAfterStyleChange,
+      theme: 'light',
+      showLabels: true,
+      showImages: false,
+    });
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-left');
+  });
+
+  test('should handle map becoming null', () => {
+    const { rerender } = renderHook(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ({ map }: { map: any }) =>
+        useStyleSwitcher(map, {
+          styles: mockStyles,
+          activeStyleId: 'voyager',
+        }),
+      {
+        initialProps: { map: mockMap },
+      }
+    );
+
+    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+
+    // Set map to null
+    rerender({ map: null });
+
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+  });
+
+  test('should not crash when trying to remove control from cleaned up map', () => {
+    const { unmount } = renderHook(() =>
+      useStyleSwitcher(mockMap, {
+        styles: mockStyles,
+        activeStyleId: 'voyager',
+      })
+    );
+
+    // Should not throw when unmounting
+    expect(() => unmount()).not.toThrow();
+    expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
+  });
+});

--- a/src/tests/useStyleSwitcher.test.ts
+++ b/src/tests/useStyleSwitcher.test.ts
@@ -18,14 +18,14 @@ describe('useStyleSwitcher', () => {
     {
       id: 'voyager',
       name: 'Voyager',
-      image: 'https://example.com/voyager.png',
+      image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
       styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       description: 'Voyager style from Carto',
     },
     {
       id: 'positron',
       name: 'Positron',
-      image: 'https://example.com/positron.png',
+      image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
       styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
       description: 'Positron style from Carto',
     },

--- a/src/tests/useStyleSwitcher.test.ts
+++ b/src/tests/useStyleSwitcher.test.ts
@@ -11,21 +11,25 @@ jest.mock('../components/StyleSwitcherControl', () => ({
   StyleSwitcherControl: jest.fn(),
 }));
 
-const MockedStyleSwitcherControl = StyleSwitcherControl as jest.MockedClass<typeof StyleSwitcherControl>;
+const MockedStyleSwitcherControl = StyleSwitcherControl as jest.MockedClass<
+  typeof StyleSwitcherControl
+>;
 
 describe('useStyleSwitcher', () => {
   const mockStyles: StyleItem[] = [
     {
       id: 'voyager',
       name: 'Voyager',
-      image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
+      image:
+        'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/voyager.png',
       styleUrl: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       description: 'Voyager style from Carto',
     },
     {
       id: 'positron',
       name: 'Positron',
-      image: 'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
+      image:
+        'https://github.com/muimsd/map-gl-style-switcher/tree/main/public/positron.png',
       styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
       description: 'Positron style from Carto',
     },
@@ -81,7 +85,10 @@ describe('useStyleSwitcher', () => {
       styles: mockStyles,
       activeStyleId: 'voyager',
     });
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-right'
+    );
   });
 
   test('should use custom position when provided', () => {
@@ -93,7 +100,10 @@ describe('useStyleSwitcher', () => {
       })
     );
 
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'bottom-left');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'bottom-left'
+    );
   });
 
   test('should remove control when component unmounts', () => {
@@ -104,7 +114,10 @@ describe('useStyleSwitcher', () => {
       })
     );
 
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-right'
+    );
 
     unmount();
 
@@ -130,13 +143,19 @@ describe('useStyleSwitcher', () => {
       }
     );
 
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-right'
+    );
 
     // Change the map
     rerender({ map: newMockMap });
 
     expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
-    expect(newMockMap.addControl).toHaveBeenCalledWith(expect.any(Object), 'top-right');
+    expect(newMockMap.addControl).toHaveBeenCalledWith(
+      expect.any(Object),
+      'top-right'
+    );
   });
 
   test('should recreate control when options change', () => {
@@ -147,8 +166,7 @@ describe('useStyleSwitcher', () => {
 
     const { rerender } = renderHook(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ({ options }: { options: any }) => 
-        useStyleSwitcher(mockMap, options),
+      ({ options }: { options: any }) => useStyleSwitcher(mockMap, options),
       {
         initialProps: {
           options: initialOptions,
@@ -195,13 +213,19 @@ describe('useStyleSwitcher', () => {
       }
     );
 
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-right'
+    );
 
     // Change position
     rerender({ position: 'bottom-left' });
 
     expect(mockMap.removeControl).toHaveBeenCalledWith(mockControlInstance);
-    expect(mockMap.addControl).toHaveBeenCalledWith(expect.any(Object), 'bottom-left');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      expect.any(Object),
+      'bottom-left'
+    );
   });
 
   test('should handle all control options', () => {
@@ -230,7 +254,10 @@ describe('useStyleSwitcher', () => {
       showLabels: true,
       showImages: false,
     });
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-left');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-left'
+    );
   });
 
   test('should handle map becoming null', () => {
@@ -246,7 +273,10 @@ describe('useStyleSwitcher', () => {
       }
     );
 
-    expect(mockMap.addControl).toHaveBeenCalledWith(mockControlInstance, 'top-right');
+    expect(mockMap.addControl).toHaveBeenCalledWith(
+      mockControlInstance,
+      'top-right'
+    );
 
     // Set map to null
     rerender({ map: null });


### PR DESCRIPTION
## 🎯 Overview

Restructures the package with clean, purpose-built entry points to solve the dependency confusion for different user types.

Closes #10

## 🔧 Changes

### Entry Points
- **`map-gl-style-switcher`** - Vanilla JS/TS only (default, no React dependencies)
- **`map-gl-style-switcher/react`** - React hook for custom map instances  
- **`map-gl-style-switcher/react-map-gl`** - React component for react-map-gl integration

### Package Structure
- ✅ **Removed** redundant `/vanilla` entry point (main is already vanilla)
- ✅ **Added** `exports` field in package.json for conditional exports
- ✅ **Updated** Rollup config for multiple entry points (ES + UMD builds)
- ✅ **Created** `useStyleSwitcher` hook for custom map instances
- ✅ **Separated** React components by use case

### Dependency Management
- ✅ **Moved** React dependencies out of required peerDependencies  
- ✅ **Only** core map dependencies (maplibre-gl, mapbox-gl) as optional peers
- ✅ **Clean** separation of concerns

### Documentation
- ✅ **Clear** entry point guide with usage examples
- ✅ **Separate** installation instructions for each use case
- ✅ **Table** showing dependencies for each entry point

## 📦 Built Artifacts

```
dist/
├── index.js        # Vanilla ES module
├── index.d.ts      # Vanilla TypeScript definitions
├── index.umd.js    # UMD build for CDN
├── react.js        # React hook ES module
├── react.d.ts      # React hook TypeScript definitions
├── react-map-gl.js # React component ES module
├── react-map-gl.d.ts # React component TypeScript definitions
└── map-gl-style-switcher.css # Styles
```

## 🧪 Testing

- ✅ All 44 tests passing
- ✅ Build system working correctly
- ✅ Entry points export correct modules:
  - Main: `['StyleSwitcherControl']`
  - React: `['StyleSwitcherControl', 'useStyleSwitcher']`
  - React-Map-GL: `['MapGLStyleSwitcher', 'StyleSwitcherControl']`

## 📚 Usage Examples

### Vanilla JavaScript/TypeScript
```ts
import { StyleSwitcherControl } from 'map-gl-style-switcher';
// No React dependencies required
```

### React with Custom Map Instance
```tsx
import { useStyleSwitcher } from 'map-gl-style-switcher/react';
// Pure React hook - works with any map instance
```

### React with react-map-gl
```tsx
import { MapGLStyleSwitcher } from 'map-gl-style-switcher/react-map-gl';
// React component using react-map-gl's useControl
```

## ⚠️ Breaking Changes

- **React components** no longer exported from main entry point
- **Use** `map-gl-style-switcher/react-map-gl` for `MapGLStyleSwitcher` component
- **React dependencies** moved out of required peerDependencies

## 🎯 Benefits

- ✅ **Vanilla users**: No forced React dependencies
- ✅ **React hook users**: Pure React hook without react-map-gl dependency  
- ✅ **react-map-gl users**: Clean component integration
- ✅ **Better tree-shaking**: Only import what you need
- ✅ **Clearer documentation**: Obvious which import to use